### PR TITLE
Close #36. All tricks can be deleted from the homepage.

### DIFF
--- a/src/Controller/TrickController.php
+++ b/src/Controller/TrickController.php
@@ -16,6 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+//use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 
 class TrickController extends Controller
 {
@@ -325,6 +326,7 @@ class TrickController extends Controller
         ]);
     }
 
+
     /**
      * @Route(
      *      "/tricks/{id}/ajax-delete",
@@ -399,7 +401,7 @@ class TrickController extends Controller
     // "TRICK" and "MEDIA" if used as placeholders (see "edit.html.twig").
     /**
      * @Route(
-     *      "/tricks/{id}/medias/{mediaId}/set_cover",
+     *      "/tricks/{id}/medias/{mediaId}/set-cover",
      *      name="set_cover",
      *      requirements={"id":"\d+|TRICK","mediaId":"\d+|MEDIA"},
      *      methods={"GET","POST","DELETE"},
@@ -430,7 +432,7 @@ class TrickController extends Controller
 
     /**
      * @Route(
-     *      "/tricks/{id}/unset_cover",
+     *      "/tricks/{id}/unset-cover",
      *      name="unset_cover",
      *      requirements={"id":"\d+"},
      *      methods={"GET","POST","DELETE"},

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -144,12 +144,13 @@
                 });
             });
 
-            $(".js-delete-trick").on("click", function (e) {
+            // Delegated event to bind the "click" event also to the
+            // elements dynamically created in the future, not only 
+            // to the ones present on page load.
+            // See https://stackoverflow.com/a/1207393/10980984
+            $(document).on("click", ".js-delete-trick", function(e){
+            //$(".js-delete-trick").on("click", function (e) {
                 e.preventDefault();
-                /*let el = $(this).find(".fa-trash-alt");
-                alert(el.attr("title"));
-                el.css("opacity", 0.4).css("cursor", "default");
-                */
 
                 if(confirm("{{'confirm_delete_trick'|trans }}")) {
                     var url = $(this).attr("href");
@@ -182,14 +183,10 @@
                         loadTricks(url);
                         manageUpArrow();
                     }).fail(function () {
-                        alert("Could not delete trick.");
+                        alert("{{'trick_deletion_failed'|trans }}");
                     });                    
                 }
-                else {
-                    alert("{{'trick_deletion_failed'|trans }}");
-                }
 
-                //el.css("opacity", 1).css("cursor", "pointer");
             });
 
             $(".fa-arrow-down").on("click", function(){

--- a/templates/trick/view.html.twig
+++ b/templates/trick/view.html.twig
@@ -174,7 +174,7 @@
                     break;
                 default:
             }
-            targetElem.slideDown(400).delay(2000).slideUp(400);
+            targetElem.slideDown(400).delay(1000).slideUp(400);
         };
 
         $(document).ready(function () {

--- a/translations/gui.fr.xlf
+++ b/translations/gui.fr.xlf
@@ -173,7 +173,15 @@
             </trans-unit>
             <trans-unit id="confirm_deletion_of_trick">
                 <source>confirm_deletion_of_trick</source>
-                <target>Etes-vous certain de vouloir supprimer la figure "%trick_name%" ?</target>
+                <target>Etes-vous certain(e) de vouloir supprimer la figure "%trick_name%" ?</target>
+            </trans-unit>
+            <trans-unit id="confirm_delete_trick">
+                <source>confirm_delete_trick</source>
+                <target>Etes-vous certain(e) de vouloir supprimer cette figure ?</target>
+            </trans-unit>
+            <trans-unit id="trick_deletion_failed">
+                <source>trick_deletion_failed</source>
+                <target>Echec de suppression de la figure.</target>
             </trans-unit>
             <trans-unit id="delete_trick">
                 <source>delete_trick</source>


### PR DESCRIPTION
All tricks can now be deleted from the homepage.