### PR TITLE
Close #51. Clear error message added on trick edition page for name duplication.

### DIFF
--- a/src/Controller/TrickController.php
+++ b/src/Controller/TrickController.php
@@ -115,7 +115,7 @@ class TrickController extends Controller
 
     private function handleNewTrickSubmit($trick, $request)
     {
-        $result = $this->trickManager->saveTrickToDB($trick);
+        $result = $this->trickManager->saveTrickToDB($trick, 'trick_new');
 
         $request->getSession()->getFlashBag()->add(
             $result['msg_type'],
@@ -259,14 +259,14 @@ class TrickController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $result = $this->trickManager->saveTrickToDB($trick);
+            $result = $this->trickManager->saveTrickToDB($trick, 'trick_edit', ['id' => $trick->getId()]);
 
             $request->getSession()->getFlashBag()->add(
                 $result['msg_type'],
-                $this->i18n->trans($result['message'])
+                $this->i18n->trans($result['message'], $result['message_params'])
             );
 
-            return $this->redirectToRoute($result['dest_page']);
+            return $this->redirectToRoute($result['dest_page'], $result['dest_page_params']);
         }
 
         return $this->render('trick/edit.html.twig', [

--- a/src/Service/TrickManager.php
+++ b/src/Service/TrickManager.php
@@ -33,7 +33,7 @@ class TrickManager extends Controller
     }
 
     // Inserts or updates a trick into the database.
-    public function saveTrickToDB(Trick $trick)
+    public function saveTrickToDB(Trick $trick, $fromRoute, $routeParams = [])
     {
         $result = [];
 
@@ -58,9 +58,10 @@ class TrickManager extends Controller
                     ]) . '">',
                 '%link_end%' => '</a>'
             ];
-            $result['dest_page'] = 'trick_new';
+            $result['dest_page'] = $fromRoute;
             $result['trick'] = $trick;
         }
+        $result['dest_page_params'] = $routeParams;
 
         return $result;
     }

--- a/templates/trick/edit.html.twig
+++ b/templates/trick/edit.html.twig
@@ -10,14 +10,16 @@
             style="background-image: url({{ asset('./uploads/images/tricks/' ~ cover_image) }})">
         </div>
         <div class="container main">
-            {# On affiche tous les messages flash #}
-            {% for label, messages in app.session.flashbag.all %}
-                {% for message in messages %}
-                    <div class="flash flash-{{ label }} alert-{{ label }}">
-                        {{ message }}
-                    </div>
+            <div class="well">
+                {# On affiche tous les messages flash #}
+                {% for label, messages in app.session.flashbag.all %}
+                    {% for message in messages %}
+                        <div class="flash flash-{{ label }} alert-{{ label }}">
+                            {{ message|raw }}
+                        </div>
+                    {% endfor %}
                 {% endfor %}
-            {% endfor %}
+            </div>
             <div class="trick-update-warning-title">
                 <i class="fas fa-pen" aria-hidden="true"></i>
                 {{'update_a_trick'|trans }}


### PR DESCRIPTION
Now, a clear error massage is displayed on the trick edition page when trying to set the name of an already existing trick.